### PR TITLE
build-multiarch: Disable cgo

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -38,6 +38,8 @@ jobs:
       run: go install github.com/mitchellh/gox@latest
 
     - name: Build multi-arch
+      env:
+        CGO_ENABLED: 0
       run: >
         gox -osarch='linux/amd64 darwin/amd64 windows/amd64'
         -output='build/{{.Dir}}-{{.OS}}-{{.Arch}}'


### PR DESCRIPTION
The currently built Linux binary is not compatible with non-glibc Linux distros such as Alpine, which do not contain glibc.

This is due to the use of cgo, which is enabled by default "for native builds on systems where it is expected to work".

This change disables cgo by setting CGO_ENABLED=0 so that the Linux build can run on different distros.

More info here: https://pkg.go.dev/cmd/cgo