### PR TITLE
Add flag --per-attempt-timeout

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,6 +44,8 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().DurationP("timeout", "t", 1*time.Minute,
 		"timeout to abort connection attempts")
+	rootCmd.PersistentFlags().DurationP("per-attempt-timeout", "a", 5*time.Second,
+		"per attempt timeout to abort connection attempt")
 	rootCmd.PersistentFlags().DurationP("max-delay", "d", 0,
 		"maximum delay between retry attempts")
 	rootCmd.PersistentFlags().BoolP("silent", "s", false,

--- a/cmd/wait.go
+++ b/cmd/wait.go
@@ -36,6 +36,11 @@ func runWait(cmd *cobra.Command, args []string) error {
 		panic(err)
 	}
 
+	cfg.PerAttemptTimeout, err = cmd.Flags().GetDuration("per-attempt-timeout")
+	if err != nil {
+		panic(err)
+	}
+
 	cfg.RetryMaxDelay, err = cmd.Flags().GetDuration("max-delay")
 	if err != nil {
 		panic(err)

--- a/wait/wait.go
+++ b/wait/wait.go
@@ -120,6 +120,11 @@ func (w RetryWaiter) Wait(ctx context.Context, resource string, config Config) e
 	}
 
 	return retry.Do(func() error {
+		if config.PerAttemptTimeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, config.PerAttemptTimeout)
+			defer cancel()
+		}
 		return w.Check(ctx, resource)
 	}, retryOptions...)
 }


### PR DESCRIPTION
This change enables a per-attempt timeout to be configured, and sets a default per-attempt timeout to 5s.

This is helpful for connection attempts that may take a while to fail, such as TCP connection attempts that are "denied" instead of "rejected".