### PR TITLE
workflows: Use setup-go cache

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -22,17 +22,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: 1.18
-
-      # See: https://github.com/magnetikonline/action-golang-cache
-    - name: Setup Golang caches
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-golang-
+        cache: true
 
     - name: Install Gox
       run: go install github.com/mitchellh/gox@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,17 +22,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
-
-      # See: https://github.com/magnetikonline/action-golang-cache
-      - name: Setup Golang caches
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-golang-
+          cache: true
 
       - name: Build
         run: go build -v ./...


### PR DESCRIPTION
This change simplifies workflow caching by replacing the custom caching config with setup-go cache.