### PR TITLE
fix: --timeout delayed by --per-attempt-timeout

### DIFF
--- a/wait/wait.go
+++ b/wait/wait.go
@@ -154,7 +154,7 @@ func (w RetryWaiter) Wait(ctx context.Context, resource string, config Config) e
 	return retry.Do(func() error {
 		if config.PerAttemptTimeout != nil {
 			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(context.Background(), *config.PerAttemptTimeout)
+			ctx, cancel = context.WithTimeout(ctx, *config.PerAttemptTimeout)
 			defer cancel()
 		}
 		return w.Check(ctx, resource)


### PR DESCRIPTION
The total timeout (--timeout) does not abort during an attempt when the --per-attempt-timeout is set. This can cause the real timeout to greatly exceed the specified timeout.

This change fixes the issue by passing the total timeout context to the attempt context. This allows the attempt to be aborted when the total timeout is exceeded.