### PR TITLE
Revert "fix: --timeout delayed by --per-attempt-timeout (#9)"

### DIFF
--- a/wait/wait.go
+++ b/wait/wait.go
@@ -154,7 +154,7 @@ func (w RetryWaiter) Wait(ctx context.Context, resource string, config Config) e
 	return retry.Do(func() error {
 		if config.PerAttemptTimeout != nil {
 			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, *config.PerAttemptTimeout)
+			ctx, cancel = context.WithTimeout(context.Background(), *config.PerAttemptTimeout)
 			defer cancel()
 		}
 		return w.Check(ctx, resource)


### PR DESCRIPTION
This reverts commit cdde7dbcbadb52df5fb5bff1b8d1bc30ce387c95. (PR #9)

PR #9 breaks retry logic, preventing retry from completing successfully when the first attempt results in failure.

Example response:
```
retrying: http://service.example
retrying: http://service.example
retrying: http://service.example
unavailable: http://service.example
Error: All attempts fail:
#1: GET 'http://service.example': returned status code 503
#2: Get "http://service.example": context canceled
#3: Get "http://service.example": context canceled
#4: context deadline exceeded
```