### PR TITLE
fix: --timeout delayed by --per-attempt-timeout (#13)

### DIFF
--- a/wait/wait.go
+++ b/wait/wait.go
@@ -152,11 +152,12 @@ func (w RetryWaiter) Wait(ctx context.Context, resource string, config Config) e
 	}))
 
 	return retry.Do(func() error {
+		perAttemptCtx := ctx
 		if config.PerAttemptTimeout != nil {
 			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(context.Background(), *config.PerAttemptTimeout)
+			perAttemptCtx, cancel = context.WithTimeout(ctx, *config.PerAttemptTimeout)
 			defer cancel()
 		}
-		return w.Check(ctx, resource)
+		return w.Check(perAttemptCtx, resource)
 	}, retryOptions...)
 }


### PR DESCRIPTION
The total timeout (`--timeout`) does not abort during an attempt when the `--per-attempt-timeout` is set. This can cause the real timeout to greatly exceed the specified timeout.

This change fixes the behavior so that, when the total timeout elapses, it will cancel any active attempt and exit with an error.

Fixes #13.