### PR TITLE
Add CLI tests

### DIFF
--- a/cli_test/cli_test.go
+++ b/cli_test/cli_test.go
@@ -1,0 +1,91 @@
+package cli_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"testing"
+
+	"gotest.tools/v3/icmd"
+)
+
+func TestCli(t *testing.T) {
+	cmd := exec.Command("go", "build", "-o", "cli_test/bin/netwait")
+	cmd.Dir = ".."
+	err := cmd.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	netwaitPath := "bin/netwait"
+	_, err = os.Stat(netwaitPath)
+	if err != nil {
+		t.Fatal("netwait binary is required", err)
+	}
+
+	// mock HTTP server
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+	}))
+	defer server.Close()
+
+	// mock HTTP server, returns error
+	serverFail := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(500)
+	}))
+	defer serverFail.Close()
+
+	tests := []struct {
+		name     string
+		cmd      icmd.Cmd
+		expected icmd.Expected
+	}{
+		{
+			name: "http",
+			// netwait http://127.0.0.1:34287
+			cmd: icmd.Command(netwaitPath, server.URL),
+			expected: icmd.Expected{
+				ExitCode: 0,
+				// available: http://127.0.0.1:34287
+				Out: "available: " + server.URL,
+			},
+		},
+		{
+			name: "http unavailable",
+			// netwait http://127.0.0.1:34287 --timeout 5s
+			cmd: icmd.Command(netwaitPath, serverFail.URL, "--timeout", "5s"),
+			expected: icmd.Expected{
+				ExitCode: 1,
+				// unavailable: http://127.0.0.1:34287
+				Out: "unavailable: " + serverFail.URL,
+			},
+		},
+		{
+			name: "dns",
+			// netwait localhost
+			cmd: icmd.Command(netwaitPath, "localhost"),
+			expected: icmd.Expected{
+				ExitCode: 0,
+				Out:      "available: localhost",
+			},
+		},
+		{
+			name: "multiple resources",
+			// netwait http://127.0.0.1:34287 http://127.0.0.1:34287
+			cmd: icmd.Command(netwaitPath, server.URL, server.URL),
+			expected: icmd.Expected{
+				ExitCode: 0,
+				// available: http://127.0.0.1:34287
+				// available: http://127.0.0.1:34287
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fmt.Println(os.Getwd())
+			result := icmd.RunCmd(tt.cmd)
+			result.Assert(t, tt.expected)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/gomega v1.24.1
 	github.com/spf13/cobra v1.6.1
 	golang.org/x/sync v0.1.0
+	gotest.tools/v3 v3.5.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -53,3 +53,5 @@ gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
+gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=


### PR DESCRIPTION
This change adds CLI end-to-end tests under cli_test/. These tests use gotest.tools/v3/icmd package.