### PR TITLE
Upgrade Go to 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/golang:1.24-alpine AS build
+FROM library/golang:1.26-alpine AS build
 
 WORKDIR /build
 
@@ -10,7 +10,7 @@ COPY . .
 ARG version=unspecified
 RUN go build -v -ldflags "-X 'github.com/guidewire/netwait/cmd.version=$version'"
 
-FROM library/alpine:3.17
+FROM library/alpine:3.24
 
 WORKDIR /app
 ENV PATH=$PATH:/app

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/guidewire/netwait
 
-go 1.23.0
+go 1.26
 
-toolchain go1.24.1
+toolchain go1.26.1
 
 require (
 	github.com/avast/retry-go/v4 v4.6.0


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade the project to Go 1.26 and bump Docker base images to Alpine 3.24 for a newer toolchain and security patches.

- **Dependencies**
  - Updated `go.mod` to `go 1.26` and `toolchain go1.26.1`.
  - Switched build image to `library/golang:1.26-alpine` and runtime to `library/alpine:3.24`.

- **Migration**
  - Use Go 1.26+ for local development and CI.

<sup>Written for commit b004177470469807b198def135ba15b95d06a08a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guidewire-oss/netwait/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

